### PR TITLE
Support for raw data results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,6 @@ module.exports = function(session) {
 
 		this.connection.execute(sql, params, { outFormat: oracledb.ARRAY, fetchInfo: { "DATA": { type: oracledb.STRING} } }, // Fetch as a String instead of a Stream
 		function(error, result) {
-			debug_log(result);
 
 			if (error) {
 				debug_error('Failed to get session.');
@@ -152,8 +151,8 @@ module.exports = function(session) {
 			}
 
 			try {
-				debug_log('Session result: ' + result.rows[0]);
-				var session = result.rows[0] !== undefined ? JSON.parse(result.rows[0].data) : null;
+				//debug_log('Session result: ' + result.rows[0]);
+				var session = result.rows[0] !== undefined ? JSON.parse(result.rows[0]['data'] || result.rows[0][0]) : null;
 				//debug_log('Session return: ' + session);
 
 			} catch (error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,6 +143,7 @@ module.exports = function(session) {
 
 		this.connection.execute(sql, params, { outFormat: oracledb.ARRAY, fetchInfo: { "DATA": { type: oracledb.STRING} } }, // Fetch as a String instead of a Stream
 		function(error, result) {
+			debug_log(result);
 
 			if (error) {
 				debug_error('Failed to get session.');
@@ -151,7 +152,7 @@ module.exports = function(session) {
 			}
 
 			try {
-				//debug_log('Session result: ' + result.rows[0]);
+				debug_log('Session result: ' + result.rows[0]);
 				var session = result.rows[0] !== undefined ? JSON.parse(result.rows[0].data) : null;
 				//debug_log('Session return: ' + session);
 


### PR DESCRIPTION
Session data results can be retrieved in array or object format depending on oracledb version, this change resolve the issue of ínvalid JSON format' in any case.